### PR TITLE
PHPUnit 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.1|^7.2|^7.3",
         "swaggest/json-schema": "^0.12.0",
-        "phpunit/phpunit": "^6.3|^7.0"
+        "phpunit/phpunit": "^6.3|^7.0|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12"

--- a/tests/AssertResponseTest.php
+++ b/tests/AssertResponseTest.php
@@ -10,7 +10,7 @@ class AssertResponseTest extends TestCase
 {
     protected $response;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/AssertsJsonTraitTest.php
+++ b/tests/AssertsJsonTraitTest.php
@@ -9,7 +9,7 @@ class AssertsJsonTraitTest extends TestCase
 {
     use AssertsJsonSchema;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
* matched method signature of `setUp()`
* this is backward compatible with PHPUnit 6 and 7

## Status
READY

## Description
This now supports PHPUnit 8, and still supports PHPUnit 6 & 7. There were only 2 code changes needed. I have tested all three versions locally.