### PR TITLE
Add support for phpunit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^8.0",
         "swaggest/json-schema": "^0.12.0",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This goes hand-in-hand with sixlive/laravel-json-schema-assertions#28, enabling support for Laravel 10, PHPUnit 10, and as a result, Pest 2.x